### PR TITLE
Addressing Issue #13

### DIFF
--- a/skexplain/main/PermutationImportance/abstract_runner.py
+++ b/skexplain/main/PermutationImportance/abstract_runner.py
@@ -87,7 +87,7 @@ def abstract_variable_importance(
     num_vars = len(variable_names)
 
     # Compute the original score over all the data
-    original_score = scoring_fn(training_data, scoring_data)
+    original_score = scoring_fn(training_data, scoring_data, var_idx=None)
     result_obj = ImportanceResult(method, variable_names, original_score)
 
     # This random state generator is for the predictors left permuted.
@@ -112,9 +112,7 @@ def abstract_variable_importance(
         if njobs == 1:
             result = _singlethread_iteration(selection_iter, scoring_fn)
         else:
-            result = _multithread_iteration(
-                selection_iter, scoring_fn, njobs, num_vars - i
-            )
+            result = _multithread_iteration(selection_iter, scoring_fn, njobs)
 
         next_result = add_ranks_to_dict(result, variable_names, scoring_strategy)
         best_var = min(next_result.keys(), key=lambda key: next_result[key][0])
@@ -137,13 +135,13 @@ def _singlethread_iteration(selection_iterator, scoring_fn):
     :returns: a dict of ``{var: score}``
     """
     result = dict()
-    for var, training_data, scoring_data in selection_iterator:
+    for training_data, scoring_data, var in selection_iterator:
         score = scoring_fn(training_data, scoring_data, var_idx=var)
         result[var] = score
     return result
 
 
-def _multithread_iteration(selection_iterator, scoring_fn, njobs, n_vars):
+def _multithread_iteration(selection_iterator, scoring_fn, njobs):
     """Handles a single pass of the abstract variable importance algorithm using
     multithreading
 

--- a/skexplain/main/PermutationImportance/abstract_runner.py
+++ b/skexplain/main/PermutationImportance/abstract_runner.py
@@ -65,8 +65,13 @@ def abstract_variable_importance(
     :returns: :class:`PermutationImportance.result.ImportanceResult` object
         which contains the results for each run
     """
-    training_data = verify_data(training_data)
+    #training_data = #verify_data(training_data)
     scoring_data = verify_data(scoring_data)
+    
+    # Sending the scoring_data in as training_data so that for the 
+    # forward permutation importance methods, we can un-permuted data. 
+    training_data = (scoring_data[0].copy(), scoring_data[1].copy())
+    
     scoring_strategy = verify_scoring_strategy(scoring_strategy)
     variable_names = determine_variable_names(scoring_data, variable_names)
 
@@ -100,6 +105,8 @@ def abstract_variable_importance(
         if verbose:
             print(f"Multi-pass iteration {i+1} out of {nimportant_vars}...")
 
+        # Sending the scoring_data in as training_data so that for the 
+        # forward permutation importance methods, we can un-permuted data. 
         selection_iter = selection_strategy(
             training_data,
             scoring_data,
@@ -113,7 +120,7 @@ def abstract_variable_importance(
             result = _singlethread_iteration(selection_iter, scoring_fn)
         else:
             result = _multithread_iteration(selection_iter, scoring_fn, njobs)
-
+   
         next_result = add_ranks_to_dict(result, variable_names, scoring_strategy)
         best_var = min(next_result.keys(), key=lambda key: next_result[key][0])
         best_index = np.flatnonzero(variable_names == best_var)[0]

--- a/skexplain/main/PermutationImportance/multiprocessing_utils.py
+++ b/skexplain/main/PermutationImportance/multiprocessing_utils.py
@@ -21,7 +21,11 @@ __all__ = ["pool_imap_unordered"]
 
 def worker(func, recvq, sendq):
     for args in iter(recvq.get, None):
-        result = (args[0], func(*args[1:]))
+        # The args are training_data, scoring_data, var_idx
+        # Thus, we want to return the var_idx and then 
+        # send those args to the abstract runner. 
+        result = (args[-1], func(*args))
+        
         sendq.put(result)
 
 

--- a/skexplain/main/PermutationImportance/permutation_importance.py
+++ b/skexplain/main/PermutationImportance/permutation_importance.py
@@ -92,7 +92,6 @@ def permutation_importance(
             direction=direction,
         )
 
-
 def sklearn_permutation_importance(
     model,
     scoring_data,
@@ -151,6 +150,7 @@ def sklearn_permutation_importance(
             n_permute=n_permute,
             subsample=subsample,
             random_seed=random_seed,
+            direction=direction,
             scorer_kwargs={},
         )
     else:
@@ -160,6 +160,7 @@ def sklearn_permutation_importance(
             n_permute=n_permute,
             subsample=subsample,
             random_seed=random_seed,
+            direction=direction,
             scorer_kwargs={},
         )
 

--- a/skexplain/main/PermutationImportance/selection_strategies.py
+++ b/skexplain/main/PermutationImportance/selection_strategies.py
@@ -64,9 +64,7 @@ class SelectionStrategy(object):
             if var not in self.important_vars:
                 training_data, scoring_data = self.generate_datasets(
                     self.important_vars
-                    + [
-                        var,
-                    ]
+                    + [var,]
                 )
                 yield (training_data, scoring_data, var)
 
@@ -312,7 +310,7 @@ class ForwardPermutationImportanceSelectionStrategy(SelectionStrategy):
         self.original_index = (
             scoring_inputs.index if isinstance(scoring_inputs, pd.DataFrame) else None
         )
-
+        
     def generate_datasets(self, important_variables):
         """Check each of the non-important variables. Dataset has columns which
         are non-important variables are shuffled
@@ -326,8 +324,7 @@ class ForwardPermutationImportanceSelectionStrategy(SelectionStrategy):
                     scoring_inputs
                     if i in important_variables
                     else self.shuffled_scoring_inputs,
-                    None,
-                    [i],
+                    columns = [i],
                 )
                 for i in range(self.num_vars)
             ],

--- a/skexplain/main/PermutationImportance/selection_strategies.py
+++ b/skexplain/main/PermutationImportance/selection_strategies.py
@@ -68,7 +68,7 @@ class SelectionStrategy(object):
                         var,
                     ]
                 )
-                yield (var, training_data, scoring_data)
+                yield (training_data, scoring_data, var)
 
     def __iter__(self):
         return self.generate_all_datasets()

--- a/skexplain/main/PermutationImportance/sklearn_api.py
+++ b/skexplain/main/PermutationImportance/sklearn_api.py
@@ -62,14 +62,26 @@ def predict_proba_model(model, scoring_inputs):
     return model.predict_proba(scoring_inputs)[:, 1]
 
 
+def forward_permutations(X, inds, var_idx):
+    return np.array(
+                    [
+                        X[:, i] if i == var_idx else X[inds, i]
+                        for i in range(X.shape[1])
+                    ]
+                ).T
+
 class model_scorer(object):
     """General purpose scoring method which takes a particular model, trains the
     model over the given training data, uses the trained model to predict on the
     given scoring data, and then evaluates those predictions using some
     evaluation function. Additionally provides the tools for bootstrapping the
     scores and providing a distribution of scores to be used for statistics.
+    
+    NOTE: Since these method is used internally, the scoring inputs into 
+    this method for different rounds of multipass permutation importance 
+    are already permuted for the top most features. Thus, in any current 
+    iteration, we need only permute a single column at a time. 
     """
-
     def __init__(
         self,
         model,
@@ -80,6 +92,7 @@ class model_scorer(object):
         default_score=0.0,
         n_permute=1,
         subsample=1,
+        direction='backward', 
         **kwargs
     ):
         """Initializes the scoring object by storing the training, predicting,
@@ -122,6 +135,7 @@ class model_scorer(object):
         self.default_score = default_score
         self.n_permute = n_permute
         self.subsample = subsample
+        self.direction = direction
         self.kwargs = kwargs
         self.random_seed = kwargs.get("random_seed", 42)
 
@@ -138,6 +152,8 @@ class model_scorer(object):
         """
         (training_inputs, training_outputs) = training_data
         (scoring_inputs, scoring_outputs) = scoring_data
+        
+        ##print(f'{training_inputs=}')
 
         subsample = (
             int(len(scoring_data[0]) * self.subsample)
@@ -161,9 +177,16 @@ class model_scorer(object):
             shuffled_indices = random_states[0].permutation(scoring_outputs.shape[0])
             permuted_scoring_inputs = scoring_inputs.copy()
             if var_idx is not None: 
-                permuted_scoring_inputs[:, var_idx] = scoring_inputs[
-                    shuffled_indices, var_idx
-                ]
+                if self.direction == 'backward':
+                    # Permute var @ var_idx 
+                    permuted_scoring_inputs[:, var_idx] = scoring_inputs[
+                        shuffled_indices, var_idx
+                    ]
+                else:
+                    # Un-permuted var @ var_idx
+                    permuted_scoring_inputs[:, var_idx] = training_inputs[:, var_idx]
+     
+                    
             permuted_predictions = self.prediction_fn(
                 trained_model, permuted_scoring_inputs
             )
@@ -178,17 +201,29 @@ class model_scorer(object):
             ###print('Only one permutation, but with subsampling!')
             scores = []
             rows = random_states[0].choice(scoring_outputs.shape[0], subsample)
+            
             subsampled_scoring_outputs = get_data_subset(scoring_outputs, rows)
-            subsampled_scoring_inputs = get_data_subset(scoring_inputs, rows)
+            subsampled_scoring_inputs = get_data_subset(scoring_inputs, rows)  
+                    
+            if self.direction == 'forward':
+                subsampled_training_outputs = get_data_subset(training_outputs, rows)
+                subsampled_training_inputs = get_data_subset(training_inputs, rows)  
+            
 
             shuffled_indices = random_states[0].permutation(
                 subsampled_scoring_outputs.shape[0]
             )
             permuted_scoring_inputs = subsampled_scoring_inputs.copy()
-            if var_idx is not None:    
-                permuted_scoring_inputs[:, var_idx] = subsampled_scoring_inputs[
+            if var_idx is not None: 
+                if self.direction == 'backward':
+                    # Permute var @ var_idx
+                    permuted_scoring_inputs[:, var_idx] = subsampled_scoring_inputs[
                     shuffled_indices, var_idx
-                ]
+                    ]
+                else:
+                    # Un-permute var @ var_idx
+                    permuted_scoring_inputs[:, var_idx]  = subsampled_training_inputs[:, var_idx]
+                    
             permuted_predictions = self.prediction_fn(
                 trained_model, permuted_scoring_inputs
             )
@@ -210,16 +245,27 @@ class model_scorer(object):
                 rows = random_state.choice(scoring_outputs.shape[0], subsample)
 
                 subsampled_scoring_outputs = get_data_subset(scoring_outputs, rows)
-                subsampled_scoring_inputs = get_data_subset(scoring_inputs, rows)
-
+                subsampled_scoring_inputs = get_data_subset(scoring_inputs, rows)  
+                    
+                if self.direction == 'forward':
+                    subsampled_training_outputs = get_data_subset(training_outputs, rows)
+                    subsampled_training_inputs = get_data_subset(training_inputs, rows)  
+                    
                 shuffled_indices = random_state.permutation(
                     subsampled_scoring_outputs.shape[0]
                 )
+                
                 permuted_scoring_inputs = subsampled_scoring_inputs.copy()
+                
                 if var_idx is not None:
-                    permuted_scoring_inputs[:, var_idx] = subsampled_scoring_inputs[
-                        shuffled_indices, var_idx
-                    ]
+                    if self.direction == 'backward':
+                        permuted_scoring_inputs[:, var_idx] = subsampled_scoring_inputs[
+                            shuffled_indices, var_idx
+                        ]
+                    else:
+                        # Un-permute var @ var_idx
+                        permuted_scoring_inputs[:, var_idx] = subsampled_training_inputs[:, var_idx]
+                
                 permuted_predictions = self.prediction_fn(
                     trained_model, permuted_scoring_inputs
                 )
@@ -305,7 +351,7 @@ def score_untrained_sklearn_model_with_probabilities(
 
 
 def score_trained_sklearn_model(
-    model, evaluation_fn, nbootstrap=None, subsample=1, **kwargs
+    model, evaluation_fn, n_permute=1, subsample=1, direction='backward', **kwargs
 ):
     """A convenience method which does not retrain a scikit-learn model and uses
     deterministic prediction methods to evaluate the model
@@ -333,14 +379,15 @@ def score_trained_sklearn_model(
         training_fn=get_model,
         prediction_fn=predict_model,
         evaluation_fn=evaluation_fn,
-        nbootstrap=nbootstrap,
+        n_permute=n_permute,
         subsample=subsample,
+        direction=direction, 
         **kwargs
     )
 
 
 def score_trained_sklearn_model_with_probabilities(
-    model, evaluation_fn, nbootstrap=None, subsample=1, **kwargs
+    model, evaluation_fn, n_permute=1, subsample=1, direction='backward', **kwargs
 ):
     """A convenience method which does not retrain a scikit-learn model and uses
     probabilistic prediction methods to evaluate the model
@@ -368,7 +415,8 @@ def score_trained_sklearn_model_with_probabilities(
         training_fn=get_model,
         prediction_fn=predict_proba_model,
         evaluation_fn=evaluation_fn,
-        nbootstrap=nbootstrap,
+        n_permute=n_permute,
         subsample=subsample,
+        direction=direction,
         **kwargs
     )

--- a/skexplain/main/global_explainer.py
+++ b/skexplain/main/global_explainer.py
@@ -193,7 +193,6 @@ class GlobalExplainer(Attributes):
         See calc_permutation_importance in IntepretToolkit for documentation.
 
         """
-
         if isinstance(evaluation_fn, str):
             evaluation_fn = evaluation_fn.lower()
             is_str = True
@@ -211,7 +210,6 @@ class GlobalExplainer(Attributes):
         if isinstance(evaluation_fn, str):
             evaluation_fn, scoring_strategy = self._to_scorer(evaluation_fn)
 
-            
         # Convert the scoring strategies to the appropriate 
         # style for PermutationImportance. 
         if scoring_strategy == 'maximize':
@@ -219,14 +217,13 @@ class GlobalExplainer(Attributes):
         elif scoring_strategy == 'minimize':
             scoring_strategy == 'argmin_of_mean'
 
-            
         if is_str:
             if direction == "forward":
                 if "max" in scoring_strategy:
                     scoring_strategy = scoring_strategy.replace("max", "min")
                 else:
-                    scoring_strategy = scoring_strategy.replace("min", "max")
-
+                    scoring_strategy = scoring_strategy.replace("min", "max")        
+                    
         y = pd.DataFrame(data=self.y, columns=["Test"])
 
         pi_dict = {}


### PR DESCRIPTION
Determined that the args from the selection_iter in the abstract runner were out of order, which was causing the issue (#13 ). By fixing that issue, I found I got identical errors for n_jobs=1 and >1. 

Furthermore, in addressing this issue, I found that the forward permutation importance was not being computed correctly. Data was only being permuted in the model_scorer in the sklearn_api.py and not "un-permuted". 