### PR TITLE
using ax.inset_axes for compat with matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas
 scikit-learn
-matplotlib<=3.4.3
+matplotlib
 shap>=0.30.0
 xarray>=0.16.0
 tqdm

--- a/skexplain/plot/plot_2D.py
+++ b/skexplain/plot/plot_2D.py
@@ -135,7 +135,7 @@ class PlotInterpret2D(PlotStructure):
 
         if not is_list(estimator_names):
             estimator_names = to_list(estimator_names)
-
+   
         unnormalize = kwargs.get("unnormalize", None)
         self.display_feature_names = display_feature_names
         self.display_units = display_units
@@ -283,7 +283,8 @@ class PlotInterpret2D(PlotStructure):
                     alpha=0.8,
                     norm=BoundaryNorm(boundaries=levels, ncolors=cmap.N, clip=True),
                 )
-
+            
+            """
             mark_empty = False
             if mark_empty:
                 # Do not autoscale, so that boxes at the edges (contourf only plots the bin
@@ -302,6 +303,7 @@ class PlotInterpret2D(PlotStructure):
                             alpha=0.4,
                         )
                     )
+            """
 
             if scatter:
                 idx = np.random.choice(
@@ -364,16 +366,27 @@ class PlotInterpret2D(PlotStructure):
         if only_one_model:
             major_ax = self.set_major_axis_labels(fig=fig)
             # colorbar
-            cax = inset_axes(
-                major_ax,
-                width="100%",  # width = 10% of parent_bbox width
-                height="100%",  # height : 50%
-                loc="lower center",
-                bbox_to_anchor=(0.02, -0.1, 0.8, 0.05),
-                bbox_transform=major_ax.transAxes,
-                borderpad=0,
+            #cax = major_ax.inset_axes(
+            #    major_ax,
+            #    width="100%",  # width = 10% of parent_bbox width
+            #    height="100%",  # height : 50%
+            #    loc="lower center",
+            #    bbox_to_anchor=(0.02, -0.1, 0.8, 0.05),
+            #    bbox_transform=major_ax.transAxes,
+            #    borderpad=0,
+            #)
+            
+            cax = major_ax.inset_axes(
+                bounds = (0.02, -0.1, 0.8, 0.05),
+                transform=major_ax.transAxes,
             )
-
+            #    width="100%",  # width = 10% of parent_bbox width
+            #    height="100%",  # height : 50%
+            #    loc="lower center",
+            #    borderpad=0,
+            #)
+            
+            
             self.add_colorbar(
                 fig,
                 plot_obj=cf,
@@ -384,6 +397,7 @@ class PlotInterpret2D(PlotStructure):
                 colorbar_label=colorbar_label,
                 extend="both",
             )
+            
         # Add an letter per panel for publication purposes.
         self.add_alphabet_label(n_panels, main_axes)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -65,12 +65,13 @@ class TestLR(unittest.TestCase):
         y_interact = X_interact.iloc[:,0] + X_interact.iloc[:,1] + 2.0*(X_interact.iloc[:,0] * X_interact.iloc[:,1])
         feature_names = [f"X_{i+1}" for i in range(X_interact.shape[1])]
 
-        rf_interact = RandomForestRegressor()
-        rf_interact.fit(X_interact, y_interact)
-        estimator_name = 'RF'
+        self.rf_interact = RandomForestRegressor(random_state=42)
+        self.rf_interact.fit(X_interact, y_interact)
+        self.rf_estimator_name = 'RF'
     
         self.explainer_interact = skexplain.ExplainToolkit(
-            estimators=(estimator_name, rf_interact), X=X_interact, y=y_interact, feature_names=feature_names
+            estimators=(self.rf_estimator_name, self.rf_interact), 
+            X=X_interact, y=y_interact, feature_names=feature_names
         )
         
 class TestRF:

--- a/tests/test_interpret_curves.py
+++ b/tests/test_interpret_curves.py
@@ -149,15 +149,37 @@ class TestInterpretCurves(TestLR):
     def test_2d_ale(self):
         """ Test the 2D ALE """
         # From TestInteractions
-        ale_2d = self.explainer_interact.ale(features='all_2d')
+        ale_2d = self.explainer_interact.ale(features='all_2d', n_bins=10)
         
         self.explainer_interact.plot_ale(ale_2d) 
         
-        # TODO: Check that the 2D ALE is correct!
-        # Remember that the 2D ALE is the solely 
-        # second-order interactions such that 
-        # the average effects from both features
-        # has been removed. 
+        # The 2nd order ALE is remaining effect after the 
+        # first order effects have been removed. The first order 
+        # effects having already had the average effect removed 
+        # as that the average(first order effect) == 0. 
+        
+        # Since the coefficients for each feature is 1, then 
+        # the first order effect is just X - mean(self.y). 
+        #var1_effect = ale_2d['X_1__bin_values'].values - np.mean(self.y)
+        #var2_effect = ale_2d['X_2__bin_values'].values - np.mean(self.y)
+        
+        #first_order = var1_effect[:, np.newaxis] + var2_effect[np.newaxis, :]
+        #xx,yy = np.meshgrid(ale_2d_ds['X_1__bin_values'].values,
+        #            ale_2d_ds['X_2__bin_values'].values
+        #           )
+
+        #y_pred = self.rf_interact.predict(np.c_[xx.ravel(), yy.ravel()])
+        #y_pred = y_pred.reshape(xx.shape)
+
+        # The second order effect is the prediction minus the first order effects. 
+        #second_order = y_pred - first_order
+        
+        #ale_second_order = ale_2d[f'X_1__X_2__{self.rf_estimator_name}__ale'].values
+        
+        #diff = np.absolute(ale_second_order - second_order) 
+        # This should be approximately zero, but is unlikely to be precisely zero.
+        #self.assertAlmostEqual(diff, 0., places=1)
+
 
     def test_ale_var(self):
         """ Test the 1st and 2nd ALE variance """


### PR DESCRIPTION
Addressing #12. Using ax.inset_axes instead of inset_axes for the 2D ALE/PD plotting. This was causing an issue with v. 3.5.1 of matplotlib, which is a known issue that has been addressed (https://github.com/matplotlib/matplotlib/issues/21749). With this fix, there is no longer a restriction on the matplotlib version. 